### PR TITLE
BUGFIX: Use ContentDimension preset name in EelHelper::findRandomRecordForGroup

### DIFF
--- a/Classes/Sandstorm/Newsletter/EelHelper.php
+++ b/Classes/Sandstorm/Newsletter/EelHelper.php
@@ -38,7 +38,7 @@ class EelHelper implements ProtectedContextAwareInterface {
 
 	public function findRandomRecordForGroup($identifier, $dimensions) {
 		$preset = $this->contentDimensionPresetSource->findPresetByDimensionValues('language', $dimensions['language']);
-        $currentLanguageDimension = $preset['identifier'];
+		$currentLanguageDimension = $preset['identifier'];
 		if (!$identifier) {
 			return array();
 		}

--- a/Classes/Sandstorm/Newsletter/EelHelper.php
+++ b/Classes/Sandstorm/Newsletter/EelHelper.php
@@ -37,11 +37,8 @@ class EelHelper implements ProtectedContextAwareInterface {
 
 
 	public function findRandomRecordForGroup($identifier, $dimensions) {
-		$currentLanguageDimension = NULL;
-		if (isset($dimensions['language'][0])) {
-			// TODO!!! workaround to take ... [0]
-			$currentLanguageDimension = $dimensions['language'][0];
-		}
+		$preset = $this->contentDimensionPresetSource->findPresetByDimensionValues('language', $dimensions['language']);
+        $currentLanguageDimension = $preset['identifier'];
 		if (!$identifier) {
 			return array();
 		}
@@ -51,7 +48,6 @@ class EelHelper implements ProtectedContextAwareInterface {
 		if (!$receiverGroup) {
 			return array();
 		}
-
 		if (!file_exists($receiverGroup->getCacheFileName($currentLanguageDimension))) {
 			return array();
 		}


### PR DESCRIPTION
In ReceiverGroupGenerationService::generate the preset name is used in the
filename but the EEL helper use the first value of the dimension, so by ex.
if the preset name is 'en' but the first value 'en_EN', file are generated
with the suffix 'en' but the EEL helper try to load file with 'en_EN' and
found nothing.